### PR TITLE
Security: upgrade multer to v2.0.1 to fix DoS vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-01-07
+
+### Security
+- Upgraded `multer` from v1.4.5 to v2.0.1 to resolve a Denial of Service (DoS) vulnerability.
+
 ## [0.3.0] - 2026-01-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiish",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Open-source digital business card platform with QR codes and PWA support",
   "private": false,
   "repository": {
@@ -37,7 +37,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.263.1",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.1",
     "nodemailer": "^7.0.11",
     "qrcode": "^1.5.3",
     "react": "^18.2.0",


### PR DESCRIPTION
### Security
- Upgraded `multer` from v1.4.5 to v2.0.1 to resolve multiple Denial of Service (DoS) vulnerabilities (Dependabot alerts).