### PR TITLE
feat: add Matrix to contact details

### DIFF
--- a/matrix-url.js
+++ b/matrix-url.js
@@ -1,0 +1,19 @@
+function normalizeMatrixUrl(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) return '';
+
+  let parsed;
+  try {
+    parsed = new URL(normalized);
+  } catch (error) {
+    throw new Error('Invalid Matrix URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Invalid Matrix URL');
+  }
+
+  return normalized;
+}
+
+module.exports = { normalizeMatrixUrl };

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const nodemailer = require('nodemailer');
 const util = require('util');
 const { execSync } = require('child_process');
 const sharp = require('sharp');
+const { normalizeMatrixUrl } = require('./matrix-url');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -1384,6 +1385,10 @@ const cardDataValidation = [
     }
     return true;
   }),
+  body('social.matrix').optional().custom((value) => {
+    normalizeMatrixUrl(value);
+    return true;
+  }),
   body('links').optional().isArray().withMessage('Links must be an array'),
   body('links.*.title').optional().trim().isLength({ max: 200 }).withMessage('Link title too long'),
   body('links.*.url').optional().trim().custom((value) => {
@@ -1988,7 +1993,8 @@ app.post('/api/cards/:slug', requireAuth, apiLimiter, csrfProtection, [
       linkedin: (req.body.social?.linkedin || '').trim(),
       twitter: (req.body.social?.twitter || '').trim(),
       instagram: (req.body.social?.instagram || '').trim(),
-      github: (req.body.social?.github || '').trim()
+      github: (req.body.social?.github || '').trim(),
+      matrix: normalizeMatrixUrl(req.body.social?.matrix)
     },
     theme: req.body.theme || { color: 'indigo', style: 'modern' },
     images: {

--- a/src/App.js
+++ b/src/App.js
@@ -202,7 +202,7 @@ const getDefaultTemplate = (settings) => ({
     phone: "",
     website: "",
   },
-  social: { linkedin: "", twitter: "", instagram: "", github: "" },
+  social: { linkedin: "", twitter: "", instagram: "", github: "", matrix: "" },
   theme: { color: "indigo", style: "modern" },
   images: { avatar: null, banner: null },
   links: [],
@@ -3202,6 +3202,7 @@ END:VCARD`;
            <SocialIcon url={social.twitter} icon={Twitter} label="X" themeColor={themeColor} />
            <SocialIcon url={social.instagram} icon={Instagram} label="Insta" themeColor={themeColor} />
            <SocialIcon url={social.github} icon={Github} label="Git" themeColor={themeColor} />
+           <SocialIcon url={social.matrix} icon={MessageCircle} label="Matrix" themeColor={themeColor} />
         </div>
 
         {/* Swiish logo */}
@@ -3390,6 +3391,7 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
                   <Input icon={Twitter} placeholder="Twitter / X" value={data.social.twitter} onChange={v => handleInputChange('social', 'twitter', v)} type="url" />
                   <Input icon={Instagram} placeholder="Instagram" value={data.social.instagram} onChange={v => handleInputChange('social', 'instagram', v)} type="url" />
                   <Input icon={Github} placeholder="Github" value={data.social.github} onChange={v => handleInputChange('social', 'github', v)} type="url" />
+                  <Input icon={MessageCircle} placeholder="Matrix share URL" value={data.social.matrix || ''} onChange={v => handleInputChange('social', 'matrix', v)} type="url" />
                 </div>
              </div>
            )}

--- a/tests/matrix-contact.test.js
+++ b/tests/matrix-contact.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normalizeMatrixUrl } = require('../matrix-url');
+
+test('normalizes safe Matrix share links for card storage', () => {
+  assert.equal(
+    normalizeMatrixUrl('  https://matrix.to/#/@alice:example.org  '),
+    'https://matrix.to/#/@alice:example.org'
+  );
+  assert.equal(normalizeMatrixUrl(''), '');
+  assert.throws(
+    () => normalizeMatrixUrl('javascript:alert(1)'),
+    /Invalid Matrix URL/
+  );
+});


### PR DESCRIPTION
## Description

Adds Matrix as a first-class contact option on digital cards. Matrix share URLs are trimmed, restricted to HTTP(S), stored with the existing social fields, editable in the card editor, and rendered with the other social links.

Fixes #27

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Manual test on Chrome — not run
- [ ] Manual test on Mobile — not run
- [x] Other: `OPENSSL_CONF=/dev/null node --test tests/matrix-contact.test.js` passed in the clean network-disabled verifier; `npm run build` and focused JavaScript syntax checks also passed in the pinned Node 22 image with networking disabled.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no hard-to-understand logic was added)
- [ ] I have made corresponding changes to the documentation (no user documentation change is needed for this field)
- [ ] My changes generate no new warnings (the build completed, but dependency deprecation warnings were not compared against the base)
- [x] My commit messages follow the Conventional Commits format

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1044:start -->
### Verification

[Northset proof-of-pass receipt M-1044](https://northset-oss.github.io/verification-pilot/receipts/M-1044/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1044:end -->
