### PR TITLE
feat: add custom icon upload for custom links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Custom Link Icons**: Upload a custom image icon for each custom link in the card editor, in addition to the built-in icon set
+
 ## [0.6.0] - 2026-01-26
 
 ### Added

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -81,7 +81,7 @@ Required for sending invitations and password resets.
 Persist these volumes to keep your data safe during updates:
 
 * `/app/data`: Stores the SQLite database (`cards.db`).
-* `/app/uploads`: Stores user-uploaded avatars and banners.
+* `/app/uploads`: Stores user-uploaded avatars, banners, and link icons.
 
 ### 🔗 Links
 * [Source Code on GitHub](https://github.com/MrCrin/swiish)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Swiish is a self-hostable platform for creating and sharing digital business car
 - 📱 **Progressive Web App (PWA)** - Install cards as apps on mobile devices for offline access
 - 🔲 **QR code generation** - Generate QR codes with simple URLs or full vCard contact information
 - 🔒 **Privacy controls** - Require interaction before revealing contact details, obfuscate contact info, and block search engines
-- 📤 **File uploads** - Upload custom avatars and banner images
+- 📤 **File uploads** - Upload custom avatars, banner images, and link icons
 - 🌙 **Dark mode support** - Automatic dark mode with manual toggle
 - 📱 **Responsive design** - Works beautifully on desktop, tablet, and mobile
 - 🔐 **Admin dashboard** - Manage all your cards, users, and organization settings from a central dashboard
@@ -129,7 +129,7 @@ Demo mode allows visitors to explore Swiish without requiring authentication or 
 2. Log in to access the admin dashboard at `/admin`
 3. Click "Create New Card"
 4. Enter a unique slug (e.g., `john-doe`)
-5. Fill in your contact information, upload images, customize the theme
+5. Fill in your contact information, add custom links (with optional uploaded icons), upload images, customize the theme
 6. Click "Save"
 7. Your card is now available at `http://your-domain.com/john-doe`
 

--- a/server.js
+++ b/server.js
@@ -2060,6 +2060,8 @@ app.post('/api/cards/:slug', requireAuth, apiLimiter, csrfProtection, [
       // Remove custom images if not allowed
       sanitizedData.images.avatar = '';
       sanitizedData.images.banner = '';
+      // Remove custom link icon images too
+      sanitizedData.links = sanitizedData.links.map(link => ({ ...link, iconUrl: '' }));
     }
     
     // Enforce links customisation policy

--- a/server.js
+++ b/server.js
@@ -474,6 +474,7 @@ const { randomUUID } = require('crypto');
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 const ALLOWED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp', '.gif'];
 const MAX_FILE_SIZE = parseInt(process.env.MAX_FILE_SIZE) || 5 * 1024 * 1024; // 5MB default
+const LINK_ICON_MAX_DIMENSION = 256;
 
 function sanitizeUploadUrl(value) {
   if (!value || typeof value !== 'string') return '';
@@ -1254,6 +1255,26 @@ app.post('/api/upload', requireAuth, uploadLimiter, csrfProtection, upload.singl
         log('Failed to delete invalid file:', unlinkErr.message);
       }
       return res.status(400).json({ error: 'File extension does not match file type' });
+    }
+
+    // Link icons are rendered tiny (20x20px), so downscale large uploads to keep public pages fast
+    if (req.body.purpose === 'link-icon') {
+      const metadata = await sharp(filePath).metadata();
+      const isAnimatedGif = fileType.mime === 'image/gif' && (metadata.pages || 1) > 1;
+      const exceedsLimit = metadata.width > LINK_ICON_MAX_DIMENSION || metadata.height > LINK_ICON_MAX_DIMENSION;
+      if (isAnimatedGif || exceedsLimit) {
+        const formatByMime = {
+          'image/jpeg': 'jpeg',
+          'image/png': 'png',
+          'image/webp': 'webp',
+          'image/gif': 'gif'
+        };
+        const resized = await sharp(filePath)
+          .resize(LINK_ICON_MAX_DIMENSION, LINK_ICON_MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true })
+          .toFormat(formatByMime[fileType.mime])
+          .toBuffer();
+        await fs.promises.writeFile(filePath, resized);
+      }
     }
 
     // Return the public URL

--- a/server.js
+++ b/server.js
@@ -475,6 +475,17 @@ const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'
 const ALLOWED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp', '.gif'];
 const MAX_FILE_SIZE = parseInt(process.env.MAX_FILE_SIZE) || 5 * 1024 * 1024; // 5MB default
 
+function sanitizeUploadUrl(value) {
+  if (!value || typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('/uploads/')) return '';
+  const filename = trimmed.slice('/uploads/'.length);
+  if (!filename || filename.includes('/') || filename.includes('\\') || filename.includes('..')) return '';
+  const ext = path.extname(filename).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.includes(ext)) return '';
+  return `/uploads/${filename}`.slice(0, 500);
+}
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, UPLOADS_DIR);
@@ -1392,6 +1403,7 @@ const cardDataValidation = [
     }
     return true;
   }),
+  body('links.*.iconUrl').optional().trim().isLength({ max: 500 }).withMessage('Link icon URL too long'),
   body('images.avatar').optional().trim().isLength({ max: 500 }).withMessage('Avatar URL too long'),
   body('images.banner').optional().trim().isLength({ max: 500 }).withMessage('Banner URL too long'),
   body('privacy.requireInteraction').optional().isBoolean().withMessage('requireInteraction must be a boolean'),
@@ -1999,7 +2011,8 @@ app.post('/api/cards/:slug', requireAuth, apiLimiter, csrfProtection, [
       id: link.id || Date.now(),
       title: (link.title || '').trim().substring(0, 200),
       url: (link.url || '').trim(),
-      icon: link.icon || 'link'
+      icon: link.icon || 'link',
+      iconUrl: sanitizeUploadUrl(link.iconUrl)
     })).filter(link => link.url && validator.isURL(link.url, { protocols: ['http', 'https'] })),
     privacy: {
       requireInteraction: typeof req.body.privacy?.requireInteraction === 'boolean' ? req.body.privacy.requireInteraction : true,

--- a/src/App.js
+++ b/src/App.js
@@ -3256,9 +3256,10 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
     setData(prev => ({ ...prev, [section]: { ...prev[section], [field]: value } }));
   };
 
-  const uploadImageFile = async (file) => {
+  const uploadImageFile = async (file, purpose) => {
     const formData = new FormData();
     formData.append('file', file);
+    if (purpose) formData.append('purpose', purpose);
     const res = await fetch(`${API_ENDPOINT}/upload`, {
       method: 'POST',
       credentials: 'include',
@@ -3294,7 +3295,7 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
 
     setIsUploading(true);
     try {
-      const url = await uploadImageFile(file);
+      const url = await uploadImageFile(file, 'link-icon');
       updateLink(id, 'iconUrl', url);
     } catch (error) {
       if (showAlert) showAlert('Upload failed', 'error');

--- a/src/App.js
+++ b/src/App.js
@@ -187,6 +187,14 @@ const ICON_MAP = {
   globe: Globe
 };
 
+function LinkGlyph({ link, className = "w-5 h-5" }) {
+  if (link.iconUrl) {
+    return <img src={link.iconUrl} alt="" className={`${className} object-contain`} />;
+  }
+  const Icon = ICON_MAP[link.icon] || LinkIcon;
+  return <Icon className={`${className} text-text-secondary dark:text-text-secondary-dark`} />;
+}
+
 // --- DATA TEMPLATE ---
 const getDefaultTemplate = (settings) => ({
   personal: {
@@ -3157,7 +3165,7 @@ END:VCARD`;
                     }}
                   >
                     <div className="mr-4 p-2 bg-input-bg dark:bg-input-bg-dark rounded-container shadow-sm transition-transform link-icon-container">
-                      {React.createElement(ICON_MAP[link.icon] || LinkIcon, { className: "w-5 h-5 text-text-secondary dark:text-text-secondary-dark" })}
+                      <LinkGlyph link={link} />
                     </div>
                     <span className="font-semibold text-sm flex-1">{sanitizeText(link.title || '')}</span>
                     <ExternalLink className="w-4 h-4 opacity-50" />
@@ -3186,7 +3194,7 @@ END:VCARD`;
                   }}
                 >
                   <div className="mr-4 p-2 bg-input-bg dark:bg-input-bg-dark rounded-container shadow-sm transition-transform link-icon-container">
-                    {React.createElement(ICON_MAP[link.icon] || LinkIcon, { className: "w-5 h-5 text-text-secondary dark:text-text-secondary-dark" })}
+                    <LinkGlyph link={link} />
                   </div>
                   <span className="font-semibold text-sm flex-1">{link.title}</span>
                   <ExternalLink className="w-4 h-4 opacity-50" />
@@ -3238,34 +3246,51 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
     setData(prev => ({ ...prev, [section]: { ...prev[section], [field]: value } }));
   };
 
+  const uploadImageFile = async (file) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch(`${API_ENDPOINT}/upload`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'X-CSRF-Token': csrfToken
+      },
+      body: formData
+    });
+    if (!res.ok) throw new Error('Upload failed');
+    const { url } = await res.json();
+    return url;
+  };
+
   const handleImageUpload = async (type, e) => {
     const file = e.target.files[0];
     if (!file) return;
 
     setIsUploading(true);
-    const formData = new FormData();
-    formData.append('file', file);
-
     try {
-      const res = await fetch(`${API_ENDPOINT}/upload`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'X-CSRF-Token': csrfToken
-        },
-        body: formData
-      });
-      
-      if (res.ok) {
-        const { url } = await res.json();
-        setData(prev => ({ ...prev, images: { ...prev.images, [type]: url } }));
-      } else {
-        if (showAlert) showAlert('Upload failed', 'error');
-      }
+      const url = await uploadImageFile(file);
+      setData(prev => ({ ...prev, images: { ...prev.images, [type]: url } }));
     } catch (error) {
-      if (showAlert) showAlert('Upload error', 'error');
+      if (showAlert) showAlert('Upload failed', 'error');
     } finally {
       setIsUploading(false);
+      e.target.value = '';
+    }
+  };
+
+  const handleLinkIconUpload = async (id, e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    try {
+      const url = await uploadImageFile(file);
+      updateLink(id, 'iconUrl', url);
+    } catch (error) {
+      if (showAlert) showAlert('Upload failed', 'error');
+    } finally {
+      setIsUploading(false);
+      e.target.value = '';
     }
   };
 
@@ -3277,7 +3302,8 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
     setData(prev => ({ ...prev, links: prev.links.filter(l => l.id !== id) }));
   };
   const updateLink = (id, field, value) => {
-    setData(prev => ({ ...prev, links: prev.links.map(l => l.id === id ? { ...l, [field]: value } : l) }));
+    const patch = typeof field === 'object' ? field : { [field]: value };
+    setData(prev => ({ ...prev, links: prev.links.map(l => l.id === id ? { ...l, ...patch } : l) }));
   };
 
   const reorderLinks = (oldIndex, newIndex) => {
@@ -3414,8 +3440,8 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
                         <div key={link.id} className="bg-surface dark:bg-surface-dark p-4 rounded-input border border-border dark:border-border-dark">
                           <div className="grid gap-3">
                             <div className="flex gap-3 items-center">
-                              <div className="w-10 h-10 rounded-container bg-card dark:bg-surface-dark border border-border dark:border-border-dark flex items-center justify-center shrink-0">
-                                {React.createElement(ICON_MAP[link.icon] || LinkIcon, { className: "w-5 h-5 text-text-secondary dark:text-text-secondary-dark" })}
+                              <div className="w-10 h-10 rounded-container bg-card dark:bg-surface-dark border border-border dark:border-border-dark flex items-center justify-center shrink-0 overflow-hidden">
+                                <LinkGlyph link={link} />
                               </div>
                               <input type="text" value={link.title} disabled className="flex-1 bg-card dark:bg-surface-dark border border-border dark:border-border-dark text-text-muted dark:text-text-muted-dark rounded-input px-3 py-2 text-sm cursor-not-allowed" />
                             </div>
@@ -3432,6 +3458,7 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
                   </LockedOption>
                 ) : (
                 <div className="space-y-4">
+                    {isUploading && <div className="text-sm text-indigo-600 dark:text-indigo-400 animate-pulse">Uploading image...</div>}
                     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                       <SortableContext items={data.links.map(link => link.id)} strategy={verticalListSortingStrategy}>
                         {data.links.map((link, index) => (
@@ -3478,9 +3505,13 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
                                 </button>
                                 <div className="grid gap-3 pt-6">
                                   <div className="flex gap-3 items-center">
-                                    <div className="w-10 h-10 rounded-container bg-card dark:bg-surface-dark border border-border dark:border-border-dark flex items-center justify-center shrink-0">
-                                      {React.createElement(ICON_MAP[link.icon], { className: "w-5 h-5 text-text-secondary dark:text-text-secondary-dark" })}
-                                    </div>
+                                    <label
+                                      htmlFor={`link-icon-upload-${link.id}`}
+                                      className="w-10 h-10 rounded-container bg-card dark:bg-surface-dark border border-border dark:border-border-dark flex items-center justify-center shrink-0 overflow-hidden cursor-pointer hover:border-action dark:hover:border-action-dark"
+                                      title="Upload custom icon"
+                                    >
+                                      <LinkGlyph link={link} />
+                                    </label>
                                     <input 
                                       type="text" 
                                       placeholder="Link Title (e.g. Download CV)"
@@ -3496,13 +3527,27 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
                                     onChange={(e) => updateLink(link.id, 'url', e.target.value)}
                                     className="w-full bg-card dark:bg-surface-dark border border-border dark:border-border-dark text-text-primary dark:text-text-primary-dark rounded-input px-3 py-2 text-sm focus:outline-none focus:border-action dark:focus:border-action-dark"
                                   />
-                                  {/* Simple Icon Picker */}
+                                  <input
+                                    id={`link-icon-upload-${link.id}`}
+                                    type="file"
+                                    accept="image/jpeg,image/png,image/webp,image/gif"
+                                    onChange={(e) => handleLinkIconUpload(link.id, e)}
+                                    className="hidden"
+                                  />
                                   <div className="flex gap-2 overflow-x-auto pb-2 pt-1 no-scrollbar">
+                                    <label
+                                      htmlFor={`link-icon-upload-${link.id}`}
+                                      className={`p-2 rounded-button border flex-shrink-0 cursor-pointer transition-all ${link.iconUrl ? 'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-500 dark:border-indigo-400 text-indigo-600 dark:text-indigo-300' : 'bg-card dark:bg-surface-dark border-border dark:border-border-dark text-text-muted-subtle dark:text-text-muted-dark hover:border-border dark:hover:border-border-dark'}`}
+                                      title="Upload custom icon"
+                                    >
+                                      <Upload className="w-4 h-4" />
+                                    </label>
                                     {Object.keys(ICON_MAP).map(iconKey => (
                                       <button 
                                         key={iconKey}
-                                        onClick={() => updateLink(link.id, 'icon', iconKey)}
-                                        className={`p-2 rounded-button border flex-shrink-0 transition-all ${link.icon === iconKey ? 'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-500 dark:border-indigo-400 text-indigo-600 dark:text-indigo-300' : 'bg-card dark:bg-surface-dark border-border dark:border-border-dark text-text-muted-subtle dark:text-text-muted-dark hover:border-border dark:hover:border-border-dark'}`}
+                                        type="button"
+                                        onClick={() => updateLink(link.id, { icon: iconKey, iconUrl: '' })}
+                                        className={`p-2 rounded-button border flex-shrink-0 transition-all ${!link.iconUrl && link.icon === iconKey ? 'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-500 dark:border-indigo-400 text-indigo-600 dark:text-indigo-300' : 'bg-card dark:bg-surface-dark border-border dark:border-border-dark text-text-muted-subtle dark:text-text-muted-dark hover:border-border dark:hover:border-border-dark'}`}
                                         title={iconKey}
                                       >
                                         {React.createElement(ICON_MAP[iconKey], { className: "w-4 h-4" })}

--- a/src/App.js
+++ b/src/App.js
@@ -188,8 +188,18 @@ const ICON_MAP = {
 };
 
 function LinkGlyph({ link, className = "w-5 h-5" }) {
-  if (link.iconUrl) {
-    return <img src={link.iconUrl} alt="" className={`${className} object-contain`} />;
+  const [failedIconUrl, setFailedIconUrl] = useState(null);
+  if (link.iconUrl && link.iconUrl !== failedIconUrl) {
+    return (
+      <img
+        src={link.iconUrl}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        onError={() => setFailedIconUrl(link.iconUrl)}
+        className={`${className} object-contain`}
+      />
+    );
   }
   const Icon = ICON_MAP[link.icon] || LinkIcon;
   return <Icon className={`${className} text-text-secondary dark:text-text-secondary-dark`} />;


### PR DESCRIPTION
## Description

Adds optional custom icon uploads for card links in the editor Links tab. Users can still pick a built in icon, or upload a jpg/png/webp/gif that is shown on the public card instead.
Reuses the existing `/api/upload` endpoint. Custom icon URLs are stored on each link as `iconUrl` and are restricted to `/uploads/` paths on save.

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
- [X] Manual test on Chrome
- [ ] Manual test on Mobile
- [ ] Other: (please specify)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

