### PR TITLE
feat: per-card send-your-details toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Custom Link Icons**: Upload a custom image icon for each custom link in the card editor, in addition to the built-in icon set
+- **Send Your Details Controls**: Per-card toggles to enable/disable the "Send your details" CTA and each of its channels (WhatsApp, email, drop call), with a new organisation-level `allow_send_details_customisation` lock (mirrors the existing privacy customisation lock). Resolves #30.
 
 ## [0.6.0] - 2026-01-26
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Swiish is a self-hostable platform for creating and sharing digital business car
 - 📱 **Progressive Web App (PWA)** - Install cards as apps on mobile devices for offline access
 - 🔲 **QR code generation** - Generate QR codes with simple URLs or full vCard contact information
 - 🔒 **Privacy controls** - Require interaction before revealing contact details, obfuscate contact info, and block search engines
+- 📨 **Send your details controls** - Per-card toggle for the visitor-facing "send your details" CTA, plus individual switches for WhatsApp, email, and drop-call channels
 - 📤 **File uploads** - Upload custom avatars, banner images, and link icons
 - 🌙 **Dark mode support** - Automatic dark mode with manual toggle
 - 📱 **Responsive design** - Works beautifully on desktop, tablet, and mobile
@@ -148,6 +149,19 @@ Each card supports three privacy options:
 - **Require Interaction**: Users must click "See my details" before contact info is revealed
 - **Client-Side Obfuscation**: Contact information is obfuscated in the HTML
 - **Block Robots**: Prevents search engines from indexing the card
+
+### Send Your Details Controls
+
+Each card's public page can show a "Send your details" CTA that lets visitors open
+WhatsApp, email, or a drop-call to reach the card owner. From the card editor's
+**Sharing** tab you can:
+
+- Turn the whole CTA on/off with a master switch
+- Independently enable/disable the WhatsApp, Email, and Drop call channels
+
+This is useful, for example, if you don't have a WhatsApp-capable number and want to
+disable just that channel while still allowing email or call. Organisation owners can
+lock these options for members via **Admin Settings → Send Your Details**.
 
 ### Theme Customization
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-green.svg)](https://opensource.org/licenses/AGPL-3.0)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-green.svg)](https://nodejs.org/)
 [![Docker Image](https://github.com/MrCrin/swiish/actions/workflows/build_docker_on_release.yml/badge.svg)](https://github.com/MrCrin/swiish/actions/workflows/build_docker_on_release.yml)
+[![SWH](https://archive.softwareheritage.org/badge/origin/https://github.com/MrCrin/swiish/)](https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/MrCrin/swiish) [![SWH](https://archive.softwareheritage.org/badge/swh:1:dir:1b60cb79564cb6465957034a683fd4394202b2f8/)](https://archive.softwareheritage.org/swh:1:dir:1b60cb79564cb6465957034a683fd4394202b2f8;origin=https://github.com/MrCrin/swiish;visit=swh:1:snp:c8ef0e60221b65e8cd40ec9487ea525390a50029;anchor=swh:1:rev:099cb1e9a317de654892f5106aee7fd1ac436845)
 
 **Open-source digital business card platform with QR codes and PWA support**
 

--- a/server.js
+++ b/server.js
@@ -1116,6 +1116,7 @@ app.post('/api/setup/initialize', apiLimiter, csrfProtection, [
               await dbRun("INSERT INTO organisation_settings (organisation_id, key, value, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)", [orgId, 'allow_image_customisation', 'true']);
               await dbRun("INSERT INTO organisation_settings (organisation_id, key, value, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)", [orgId, 'allow_links_customisation', 'true']);
               await dbRun("INSERT INTO organisation_settings (organisation_id, key, value, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)", [orgId, 'allow_privacy_customisation', 'true']);
+              await dbRun("INSERT INTO organisation_settings (organisation_id, key, value, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)", [orgId, 'allow_send_details_customisation', 'true']);
             } catch (err) {
               return next(err);
             }
@@ -1429,7 +1430,11 @@ const cardDataValidation = [
   body('images.banner').optional().trim().isLength({ max: 500 }).withMessage('Banner URL too long'),
   body('privacy.requireInteraction').optional().isBoolean().withMessage('requireInteraction must be a boolean'),
   body('privacy.clientSideObfuscation').optional().isBoolean().withMessage('clientSideObfuscation must be a boolean'),
-  body('privacy.blockRobots').optional().isBoolean().withMessage('blockRobots must be a boolean')
+  body('privacy.blockRobots').optional().isBoolean().withMessage('blockRobots must be a boolean'),
+  body('sendDetails.enabled').optional().isBoolean().withMessage('sendDetails.enabled must be a boolean'),
+  body('sendDetails.whatsapp').optional().isBoolean().withMessage('sendDetails.whatsapp must be a boolean'),
+  body('sendDetails.email').optional().isBoolean().withMessage('sendDetails.email must be a boolean'),
+  body('sendDetails.call').optional().isBoolean().withMessage('sendDetails.call must be a boolean')
 ];
 
 // GET All Cards (Admin Dashboard)
@@ -2039,8 +2044,18 @@ app.post('/api/cards/:slug', requireAuth, apiLimiter, csrfProtection, [
       requireInteraction: typeof req.body.privacy?.requireInteraction === 'boolean' ? req.body.privacy.requireInteraction : true,
       clientSideObfuscation: typeof req.body.privacy?.clientSideObfuscation === 'boolean' ? req.body.privacy.clientSideObfuscation : false,
       blockRobots: typeof req.body.privacy?.blockRobots === 'boolean' ? req.body.privacy.blockRobots : false
+    },
+    sendDetails: {
+      enabled: typeof req.body.sendDetails?.enabled === 'boolean' ? req.body.sendDetails.enabled : true,
+      whatsapp: typeof req.body.sendDetails?.whatsapp === 'boolean' ? req.body.sendDetails.whatsapp : true,
+      email: typeof req.body.sendDetails?.email === 'boolean' ? req.body.sendDetails.email : true,
+      call: typeof req.body.sendDetails?.call === 'boolean' ? req.body.sendDetails.call : true
     }
   };
+
+  // Defaults used when a card-level setting group is locked by the organisation
+  const DEFAULT_PRIVACY = { requireInteraction: true, clientSideObfuscation: false, blockRobots: false };
+  const DEFAULT_SEND_DETAILS = { enabled: true, whatsapp: true, email: true, call: true };
 
   // Ensure user is authenticated
   if (!req.user.id || !req.user.organisationId) {
@@ -2091,113 +2106,35 @@ app.post('/api/cards/:slug', requireAuth, apiLimiter, csrfProtection, [
       sanitizedData.links = [];
     }
     
-    // Enforce privacy customisation policy
-    if (!orgSettings.allow_privacy_customisation) {
-      // Reset to default privacy settings if customisation not allowed
-      // Get existing card to preserve current privacy settings if they match defaults
-      db.get("SELECT data FROM cards WHERE slug = ? AND user_id = ?", [slug, finalTargetUserId], (err, existingCard) => {
-        if (err) return next(err);
-        
-        if (existingCard) {
-          try {
-            const existingData = JSON.parse(existingCard.data);
-            // Only reset if user tried to change privacy settings
-            const privacyChanged = 
-              (req.body.privacy?.requireInteraction !== undefined && 
-               req.body.privacy.requireInteraction !== existingData.privacy?.requireInteraction) ||
-              (req.body.privacy?.clientSideObfuscation !== undefined && 
-               req.body.privacy.clientSideObfuscation !== existingData.privacy?.clientSideObfuscation) ||
-              (req.body.privacy?.blockRobots !== undefined && 
-               req.body.privacy.blockRobots !== existingData.privacy?.blockRobots);
-            
-            if (privacyChanged) {
-              // Keep existing privacy settings (don't allow changes)
-              sanitizedData.privacy = existingData.privacy || {
-                requireInteraction: true,
-                clientSideObfuscation: false,
-                blockRobots: false
-              };
-            } else {
-              // No change attempted, use existing
-              sanitizedData.privacy = existingData.privacy || sanitizedData.privacy;
-            }
-          } catch (e) {
-            // If parsing fails, use defaults
-            sanitizedData.privacy = {
-              requireInteraction: true,
-              clientSideObfuscation: false,
-              blockRobots: false
-            };
-          }
-        } else {
-          // New card, use defaults
-          sanitizedData.privacy = {
-            requireInteraction: true,
-            clientSideObfuscation: false,
-            blockRobots: false
-          };
-        }
-        
-        // Check if card exists to get short code, or generate new one
-        db.get("SELECT short_code FROM cards WHERE slug = ? AND user_id = ?", [slug, finalTargetUserId], (err, existingCardWithCode) => {
-          if (err) return next(err);
-          
-          const existingShortCode = existingCardWithCode?.short_code;
-          
-          // If card exists with short code, use it; otherwise generate new one
-          if (existingShortCode) {
-            // Card exists with short code, just update data
-            const jsonContent = JSON.stringify(sanitizedData);
-            
-            const query = `
-              UPDATE cards 
-              SET data = ?, updated_at = CURRENT_TIMESTAMP
-              WHERE slug = ? AND user_id = ?
-            `;
+    // Enforce privacy / send-details customisation locks.
+    // When a group is locked by the organisation, the card keeps its existing stored
+    // values for that group (or the group's defaults for a brand-new card) regardless
+    // of what was submitted in this request.
+    const privacyLocked = !orgSettings.allow_privacy_customisation;
+    const sendDetailsLocked = !orgSettings.allow_send_details_customisation;
 
-            db.run(query, [jsonContent, slug, finalTargetUserId], async function(err) {
-              if (err) return next(err);
-              await invalidatePreviewCache(slug, existingShortCode);
-              res.json({ success: true, slug, shortCode: existingShortCode });
-            });
-          } else {
-            // Card doesn't exist or has no short code, generate one
-            ensureUniqueShortCode(db, (err, shortCode) => {
-              if (err) return next(err);
+    // Finishes sanitizedData (applying any locked-group overrides) and performs the
+    // insert/update. Shared by both the locked and unlocked paths below so the save
+    // logic only exists once.
+    const saveCard = (existingData) => {
+      if (privacyLocked) {
+        sanitizedData.privacy = existingData?.privacy || DEFAULT_PRIVACY;
+      }
+      if (sendDetailsLocked) {
+        sanitizedData.sendDetails = existingData?.sendDetails || DEFAULT_SEND_DETAILS;
+      }
 
-              const jsonContent = JSON.stringify(sanitizedData);
-
-              const query = `
-                INSERT INTO cards (slug, user_id, short_code, data, updated_at)
-                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
-                ON CONFLICT(slug, user_id) DO UPDATE SET
-                  data = excluded.data,
-                  short_code = COALESCE(cards.short_code, excluded.short_code),
-                  updated_at = CURRENT_TIMESTAMP
-              `;
-
-              db.run(query, [slug, finalTargetUserId, shortCode, jsonContent], async function(err) {
-                if (err) return next(err);
-                await invalidatePreviewCache(slug, shortCode);
-                res.json({ success: true, slug, shortCode });
-              });
-            });
-          }
-        });
-      });
-    } else {
-      // Privacy customisation allowed, save normally
       // Check if card exists to get short code, or generate new one
       db.get("SELECT short_code FROM cards WHERE slug = ? AND user_id = ?", [slug, finalTargetUserId], (err, existingCardWithCode) => {
         if (err) return next(err);
-        
+
         const existingShortCode = existingCardWithCode?.short_code;
-        
+
         // If card exists with short code, use it; otherwise generate new one
         if (existingShortCode) {
           // Card exists with short code, just update data
           const jsonContent = JSON.stringify(sanitizedData);
-          
+
           const query = `
             UPDATE cards 
             SET data = ?, updated_at = CURRENT_TIMESTAMP
@@ -2233,6 +2170,26 @@ app.post('/api/cards/:slug', requireAuth, apiLimiter, csrfProtection, [
           });
         }
       });
+    };
+
+    if (privacyLocked || sendDetailsLocked) {
+      // Need the existing card's data to preserve locked group(s)
+      db.get("SELECT data FROM cards WHERE slug = ? AND user_id = ?", [slug, finalTargetUserId], (err, existingCard) => {
+        if (err) return next(err);
+
+        let existingData = null;
+        if (existingCard) {
+          try {
+            existingData = JSON.parse(existingCard.data);
+          } catch (e) {
+            existingData = null;
+          }
+        }
+
+        saveCard(existingData);
+      });
+    } else {
+      saveCard(null);
     }
     });
   };
@@ -2344,6 +2301,7 @@ const getOrganizationSettings = (organisationId, callback) => {
     if (settings.allow_image_customisation === undefined) settings.allow_image_customisation = true;
     if (settings.allow_links_customisation === undefined) settings.allow_links_customisation = true;
     if (settings.allow_privacy_customisation === undefined) settings.allow_privacy_customisation = true;
+    if (settings.allow_send_details_customisation === undefined) settings.allow_send_details_customisation = true;
     
     callback(null, settings);
   });
@@ -2455,6 +2413,9 @@ app.get('/api/admin/settings', requireAuth, requireRole('owner'), apiLimiter, (r
     if (settings.allow_privacy_customisation === undefined) {
       settings.allow_privacy_customisation = true;
     }
+    if (settings.allow_send_details_customisation === undefined) {
+      settings.allow_send_details_customisation = true;
+    }
     
     log('GET /api/admin/settings - Returning settings', {
       organisationId: req.user.organisationId,
@@ -2465,6 +2426,7 @@ app.get('/api/admin/settings', requireAuth, requireRole('owner'), apiLimiter, (r
         allow_image_customisation: settings.allow_image_customisation,
         allow_links_customisation: settings.allow_links_customisation,
         allow_privacy_customisation: settings.allow_privacy_customisation,
+        allow_send_details_customisation: settings.allow_send_details_customisation,
         theme_colors_count: settings.theme_colors?.length
       }
     });
@@ -2503,7 +2465,8 @@ app.post('/api/admin/settings', requireAuth, requireRole('owner'), apiLimiter, c
   body('allow_theme_customisation').optional().isBoolean().withMessage('allow_theme_customisation must be a boolean'),
   body('allow_image_customisation').optional().isBoolean().withMessage('allow_image_customisation must be a boolean'),
   body('allow_links_customisation').optional().isBoolean().withMessage('allow_links_customisation must be a boolean'),
-  body('allow_privacy_customisation').optional().isBoolean().withMessage('allow_privacy_customisation must be a boolean')
+  body('allow_privacy_customisation').optional().isBoolean().withMessage('allow_privacy_customisation must be a boolean'),
+  body('allow_send_details_customisation').optional().isBoolean().withMessage('allow_send_details_customisation must be a boolean')
 ], handleValidationErrors, (req, res, next) => {
   // Ensure user is authenticated and has organization
   if (!req.user.organisationId) {
@@ -2517,7 +2480,8 @@ app.post('/api/admin/settings', requireAuth, requireRole('owner'), apiLimiter, c
     allow_theme_customisation,
     allow_image_customisation,
     allow_links_customisation,
-    allow_privacy_customisation
+    allow_privacy_customisation,
+    allow_send_details_customisation
   } = req.body;
   
   log('POST /api/admin/settings - Received settings update', {
@@ -2527,6 +2491,7 @@ app.post('/api/admin/settings', requireAuth, requireRole('owner'), apiLimiter, c
     allow_image_customisation,
     allow_links_customisation,
     allow_privacy_customisation,
+    allow_send_details_customisation,
   theme_variant,
     theme_colors_count: theme_colors?.length
   });
@@ -2621,6 +2586,7 @@ app.post('/api/admin/settings', requireAuth, requireRole('owner'), apiLimiter, c
   saveToggle('allow_image_customisation', allow_image_customisation);
   saveToggle('allow_links_customisation', allow_links_customisation);
   saveToggle('allow_privacy_customisation', allow_privacy_customisation);
+  saveToggle('allow_send_details_customisation', allow_send_details_customisation);
   
   // Wait for all database operations to complete before sending response
   Promise.all(promises)
@@ -4215,7 +4181,11 @@ async function seedDemoData() {
       { key: 'allow_theme_customisation', value: '1' },
       { key: 'allow_image_customisation', value: '1' },
       { key: 'allow_links_customisation', value: '1' },
-      { key: 'allow_privacy_customisation', value: '1' }
+      { key: 'allow_privacy_customisation', value: '1' },
+      // NOTE: getOrganizationSettings() parses allow_* values as `value === 'true'`, so
+      // the '1' values above actually evaluate to false for this demo org (pre-existing
+      // bug, out of scope here). Using 'true' for the new key to match the parser.
+      { key: 'allow_send_details_customisation', value: 'true' }
     ];
 
     for (const setting of settings) {

--- a/src/App.js
+++ b/src/App.js
@@ -228,6 +228,12 @@ const getDefaultTemplate = (settings) => ({
     requireInteraction: true,  // ON by default
     clientSideObfuscation: false,  // OFF by default
     blockRobots: false  // OFF by default
+  },
+  sendDetails: {
+    enabled: true,  // ON by default (master switch)
+    whatsapp: true,  // ON by default
+    email: true,  // ON by default
+    call: true  // ON by default
   }
 });
 
@@ -2467,7 +2473,7 @@ function PublicCardRoute({ view, isPublicLoading, error, data, settings, darkMod
 }
 
 function CardDisplay({ data, settings, darkMode, toggleDarkMode, showAlert }) {
-  const { personal = {}, contact = {}, social = {}, images = {}, theme = { color: 'indigo' }, links = [], privacy = {} } = data;
+  const { personal = {}, contact = {}, social = {}, images = {}, theme = { color: 'indigo' }, links = [], privacy = {}, sendDetails = {} } = data;
   const themeColor = settings?.theme_colors?.find(c => c.name === theme.color);
   const [showQR, setShowQR] = useState(false);
   const [qrMode, setQrMode] = useState(() => {
@@ -2510,7 +2516,16 @@ function CardDisplay({ data, settings, darkMode, toggleDarkMode, showAlert }) {
     : null;
 
   const dropCallLink = ownerPhone ? `tel:${ownerPhone}` : null;
-  
+
+  // "Send your details" visibility, gated by per-card master + per-channel toggles.
+  // Use `!== false` so cards saved before this feature existed keep their current
+  // (fully enabled) behaviour.
+  const sendDetailsEnabled = sendDetails.enabled !== false;
+  const showWhatsappOption = sendDetailsEnabled && sendDetails.whatsapp !== false && !!whatsappLink;
+  const showEmailSendOption = sendDetailsEnabled && sendDetails.email !== false && !!emailLink;
+  const showDropCallOption = sendDetailsEnabled && sendDetails.call !== false && !!dropCallLink;
+  const showSendDetailsBlock = showWhatsappOption || showEmailSendOption || showDropCallOption;
+
   // Helper functions for obfuscation
   const obfuscateContact = (value) => {
     if (!value) return '';
@@ -2534,6 +2549,14 @@ function CardDisplay({ data, settings, darkMode, toggleDarkMode, showAlert }) {
     document.body.classList.add(`theme-${variant}`);
     applyThemeCssVars(variant);
   }, [settings]);
+
+  // Collapse the send-options panel if the block becomes hidden (e.g. while editing
+  // toggles live in the editor preview) so it never opens onto an empty panel.
+  useEffect(() => {
+    if (!showSendDetailsBlock && showSendOptions) {
+      setShowSendOptions(false);
+    }
+  }, [showSendDetailsBlock, showSendOptions]);
   
   // UPDATED: Set Title
   useEffect(() => {
@@ -3091,56 +3114,58 @@ END:VCARD`;
         </div>
 
         {/* Send your details CTA */}
-        <div className="mb-8">
-          <button
-            type="button"
-            onClick={() => setShowSendOptions(open => !open)}
-            className="w-full flex items-center justify-center gap-2 py-3.5 rounded-full font-semibold bg-confirm text-confirm-text dark:bg-confirm-dark dark:text-confirm-text-dark hover:opacity-90 transition-colors shadow-lg active:scale-[0.98]"
-          >
-            <MessageCircle className="w-5 h-5" />
-            {showSendOptions ? 'Hide send options' : 'Send your details'}
-          </button>
+        {showSendDetailsBlock && (
+          <div className="mb-8">
+            <button
+              type="button"
+              onClick={() => setShowSendOptions(open => !open)}
+              className="w-full flex items-center justify-center gap-2 py-3.5 rounded-full font-semibold bg-confirm text-confirm-text dark:bg-confirm-dark dark:text-confirm-text-dark hover:opacity-90 transition-colors shadow-lg active:scale-[0.98]"
+            >
+              <MessageCircle className="w-5 h-5" />
+              {showSendOptions ? 'Hide send options' : 'Send your details'}
+            </button>
 
-          {showSendOptions && (
-            <div className="mt-3 space-y-2 rounded-card border border-border dark:border-border-dark bg-surface/60 dark:bg-card-dark/60 p-3 text-left">
-              {whatsappLink && (
-                <a
-                  href={whatsappLink}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="w-full flex items-center justify-center gap-2 py-3 rounded-full font-semibold bg-success dark:bg-success-dark text-white hover:bg-success-hover dark:hover:bg-success-hover-dark transition-colors"
-                >
-                  <MessageCircle className="w-5 h-5" />
-                  WhatsApp me your number
-                </a>
-              )}
+            {showSendOptions && (
+              <div className="mt-3 space-y-2 rounded-card border border-border dark:border-border-dark bg-surface/60 dark:bg-card-dark/60 p-3 text-left">
+                {showWhatsappOption && (
+                  <a
+                    href={whatsappLink}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="w-full flex items-center justify-center gap-2 py-3 rounded-full font-semibold bg-success dark:bg-success-dark text-white hover:bg-success-hover dark:hover:bg-success-hover-dark transition-colors"
+                  >
+                    <MessageCircle className="w-5 h-5" />
+                    WhatsApp me your number
+                  </a>
+                )}
 
-              {emailLink && (
-                <a
-                  href={emailLink}
-                  className="w-full flex items-center justify-center gap-2 py-3 rounded-full font-semibold bg-surface dark:bg-surface-dark text-text-primary dark:text-text-primary-dark hover:bg-surface dark:hover:bg-surface-dark transition-colors border border-border dark:border-border-dark"
-                >
-                  <Mail className="w-5 h-5" />
-                  Email me your details
-                </a>
-              )}
+                {showEmailSendOption && (
+                  <a
+                    href={emailLink}
+                    className="w-full flex items-center justify-center gap-2 py-3 rounded-full font-semibold bg-surface dark:bg-surface-dark text-text-primary dark:text-text-primary-dark hover:bg-surface dark:hover:bg-surface-dark transition-colors border border-border dark:border-border-dark"
+                  >
+                    <Mail className="w-5 h-5" />
+                    Email me your details
+                  </a>
+                )}
 
-              {dropCallLink && (
-                <a
-                  href={dropCallLink}
-                  className="w-full flex items-center justify-center gap-2 py-3 rounded-full font-semibold bg-surface dark:bg-surface-dark text-text-primary dark:text-text-primary-dark hover:bg-surface dark:hover:bg-surface-dark transition-colors border border-border dark:border-border-dark"
-                >
-                  <Phone className="w-5 h-5" />
-                  Drop call me your number
-                </a>
-              )}
+                {showDropCallOption && (
+                  <a
+                    href={dropCallLink}
+                    className="w-full flex items-center justify-center gap-2 py-3 rounded-full font-semibold bg-surface dark:bg-surface-dark text-text-primary dark:text-text-primary-dark hover:bg-surface dark:hover:bg-surface-dark transition-colors border border-border dark:border-border-dark"
+                  >
+                    <Phone className="w-5 h-5" />
+                    Drop call me your number
+                  </a>
+                )}
 
-              <p className="mt-1 text-[11px] text-text-muted dark:text-text-muted-dark text-center">
-                Only shared with me, never sold.
-              </p>
-            </div>
-          )}
-        </div>
+                <p className="mt-1 text-[11px] text-text-muted dark:text-text-muted-dark text-center">
+                  Only shared with me, never sold.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
 
         {links.length > 0 && (
           <div className="flex flex-col gap-3 mb-8">
@@ -3379,7 +3404,7 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
 
         <div className="flex-1 p-6 space-y-8">
            <div className="flex p-1 bg-surface dark:bg-surface-dark rounded-input mb-6">
-              {['details', 'links', 'images', 'style', 'privacy'].map(tab => (
+              {['details', 'links', 'images', 'style', 'sharing', 'privacy'].map(tab => (
                 <button key={tab} onClick={() => setActiveTab(tab)} className={`flex-1 py-2 text-sm font-medium rounded-button capitalize transition-all ${activeTab === tab ? 'bg-card dark:bg-surface-dark shadow text-text-primary dark:text-text-primary-dark' : 'text-text-muted dark:text-text-muted-dark hover:text-text-primary dark:hover:text-text-primary-dark'}`}>{tab}</button>
               ))}
            </div>
@@ -3634,6 +3659,21 @@ function EditorView({ data, setData, onBack, onSave, slug, settings, csrfToken, 
                </div>
             )}
 
+            {activeTab === 'sharing' && (
+              <div className="space-y-6">
+                {settings?.allow_send_details_customisation === false ? (
+                  <LockedOption message="Your organisation has disabled send-your-details customisation. This is controlled by your organisation.">
+                    <SendDetailsToggles data={data} onChange={() => {}} />
+                  </LockedOption>
+                ) : (
+                  <SendDetailsToggles
+                    data={data}
+                    onChange={(field, checked) => handleInputChange('sendDetails', field, checked)}
+                  />
+                )}
+              </div>
+            )}
+
             {activeTab === 'privacy' && (
               <div className="space-y-6">
                 {settings?.allow_privacy_customisation === false ? (
@@ -3766,6 +3806,56 @@ function Toggle({ label, description, checked, onChange }) {
             }`}
           />
         </button>
+      </div>
+    </div>
+  );
+}
+
+function SendDetailsToggles({ data, onChange }) {
+  const sendDetails = data.sendDetails || {};
+  const masterEnabled = sendDetails.enabled ?? true;
+  const hasPhone = !!(data.contact?.phone || '').trim();
+
+  return (
+    <div className="space-y-6">
+      <Toggle
+        label="Send your details"
+        description="Shows a button on your public card that lets visitors send you their own contact details."
+        checked={masterEnabled}
+        onChange={(checked) => onChange('enabled', checked)}
+      />
+      <div className="h-px bg-border-subtle" />
+      <div className={`space-y-6 ${masterEnabled ? '' : 'opacity-50 pointer-events-none'}`}>
+        <div>
+          <Toggle
+            label="WhatsApp"
+            description="Lets visitors open WhatsApp with a pre-filled message to your number. Requires a WhatsApp-capable phone number."
+            checked={sendDetails.whatsapp ?? true}
+            onChange={(checked) => onChange('whatsapp', checked)}
+          />
+          {!hasPhone && (
+            <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">Add a phone number in Details to use this.</p>
+          )}
+        </div>
+        <div className="h-px bg-border-subtle" />
+        <Toggle
+          label="Email"
+          description="Lets visitors open their email client with a pre-filled message to your email address."
+          checked={sendDetails.email ?? true}
+          onChange={(checked) => onChange('email', checked)}
+        />
+        <div className="h-px bg-border-subtle" />
+        <div>
+          <Toggle
+            label="Drop call"
+            description="Lets visitors call your number so you have a missed-call record of their number."
+            checked={sendDetails.call ?? true}
+            onChange={(checked) => onChange('call', checked)}
+          />
+          {!hasPhone && (
+            <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">Add a phone number in Details to use this.</p>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -4751,7 +4841,8 @@ function SettingsView({ settings, setSettings, onBack, onSave, apiCall, showAler
     allow_theme_customisation: settings.allow_theme_customisation !== undefined ? Boolean(settings.allow_theme_customisation) : true,
     allow_image_customisation: settings.allow_image_customisation !== undefined ? Boolean(settings.allow_image_customisation) : true,
     allow_links_customisation: settings.allow_links_customisation !== undefined ? Boolean(settings.allow_links_customisation) : true,
-    allow_privacy_customisation: settings.allow_privacy_customisation !== undefined ? Boolean(settings.allow_privacy_customisation) : true
+    allow_privacy_customisation: settings.allow_privacy_customisation !== undefined ? Boolean(settings.allow_privacy_customisation) : true,
+    allow_send_details_customisation: settings.allow_send_details_customisation !== undefined ? Boolean(settings.allow_send_details_customisation) : true
   });
   const [editingColorIndex, setEditingColorIndex] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -4781,7 +4872,8 @@ function SettingsView({ settings, setSettings, onBack, onSave, apiCall, showAler
       allow_theme_customisation: settings.allow_theme_customisation !== undefined ? Boolean(settings.allow_theme_customisation) : true,
       allow_image_customisation: settings.allow_image_customisation !== undefined ? Boolean(settings.allow_image_customisation) : true,
       allow_links_customisation: settings.allow_links_customisation !== undefined ? Boolean(settings.allow_links_customisation) : true,
-      allow_privacy_customisation: settings.allow_privacy_customisation !== undefined ? Boolean(settings.allow_privacy_customisation) : true
+      allow_privacy_customisation: settings.allow_privacy_customisation !== undefined ? Boolean(settings.allow_privacy_customisation) : true,
+      allow_send_details_customisation: settings.allow_send_details_customisation !== undefined ? Boolean(settings.allow_send_details_customisation) : true
     });
   }, [settings]);
 
@@ -4821,7 +4913,8 @@ function SettingsView({ settings, setSettings, onBack, onSave, apiCall, showAler
           allow_theme_customisation: Boolean(localSettings.allow_theme_customisation),
           allow_image_customisation: Boolean(localSettings.allow_image_customisation),
           allow_links_customisation: Boolean(localSettings.allow_links_customisation),
-          allow_privacy_customisation: Boolean(localSettings.allow_privacy_customisation)
+          allow_privacy_customisation: Boolean(localSettings.allow_privacy_customisation),
+          allow_send_details_customisation: Boolean(localSettings.allow_send_details_customisation)
         })
       });
 
@@ -5141,6 +5234,20 @@ function SettingsView({ settings, setSettings, onBack, onSave, apiCall, showAler
                   description="When enabled, users can modify privacy options (require interaction, obfuscation, block robots). When disabled, privacy settings will be locked to organisation defaults."
                   checked={localSettings.allow_privacy_customisation === true}
                   onChange={(checked) => setLocalSettings(prev => ({ ...prev, allow_privacy_customisation: checked }))}
+                />
+              </div>
+
+              {/* Send Your Details Group */}
+              <div className="bg-surface dark:bg-card-dark/50 rounded-input p-5 space-y-4">
+                <div>
+                  <h3 className="text-sm font-semibold text-text-primary dark:text-text-primary-dark mb-2">Send Your Details</h3>
+                  <p className="text-xs text-text-secondary dark:text-text-muted-dark mb-4">Control whether users can change the send-your-details options on their cards (the WhatsApp/email/call CTA shown to visitors).</p>
+                </div>
+                <Toggle
+                  label="Allow users to change send-your-details options"
+                  description="When enabled, users can enable/disable the send-your-details CTA and its individual channels. When disabled, these options are locked to their current values."
+                  checked={localSettings.allow_send_details_customisation === true}
+                  onChange={(checked) => setLocalSettings(prev => ({ ...prev, allow_send_details_customisation: checked }))}
                 />
               </div>
                 </div>


### PR DESCRIPTION
## Summary

Adds a master switch plus per-channel toggles (WhatsApp, email, drop call) for the public "Send your details" CTA on a card. Card owners can now disable the whole CTA, or just the WhatsApp channel specifically, without losing email/call lead capture.

Closes #30

### Context

The "Send your details" block is client-only deep links (`wa.me`, `mailto:`, `tel:`) built from the card owner's own contact fields — nothing is sent server-side. The reported problem is that visitors are always offered the WhatsApp option even when the owner has no WhatsApp-capable (non-VOIP) number.

## Changes

- **`src/App.js`**
  - New `sendDetails` field group in the default card template (`enabled`, `whatsapp`, `email`, `call`), all defaulting to `true` so existing cards keep their current behaviour.
  - `CardDisplay` now gates the CTA and each channel link on these flags (using `!== false` so legacy cards without the key stay fully enabled). The whole block hides if no channel remains enabled.
  - New **Sharing** tab in the card editor (`SendDetailsToggles` component) with a master toggle and three channel toggles; channel toggles grey out when the master is off, and a hint is shown if no phone number is set. Locked via the existing `LockedOption` pattern when disabled by the organisation.
  - Org Admin Settings: new "Send Your Details" group with an `allow_send_details_customisation` toggle, following the same pattern as the existing theme/image/links/privacy customisation locks.
- **`server.js`**
  - Validation + sanitisation for `sendDetails.{enabled,whatsapp,email,call}` on `POST /api/cards/:slug`.
  - New `allow_send_details_customisation` organisation setting (defaults, `GET`/`POST /api/admin/settings`, org-creation seed, demo seed).
  - Refactored the privacy lock-enforcement branch so the privacy lock and the new send-details lock share a single save path instead of duplicating the insert/update logic.
- **`README.md` / `CHANGELOG.md`** updated to document the feature.

